### PR TITLE
Fix touch preview

### DIFF
--- a/js/Utils.js
+++ b/js/Utils.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 	
-	$('#imageSelection').children('li').bind('touchstart mousedown', function(e) {
+	$('#imageSelection').children('li').bind('click', function(e) {
 	    $('#imageTextfield').val($(this).children('a').children('img').attr('src'));
 	});
 	


### PR DESCRIPTION
So on mobile devices, when i scroll through the preview images(with touch interaction), the listener will be triggered and change the text at the bottom to that image source, although i don't have any intent to select that image.
